### PR TITLE
use aws-sdk-s3 specifically

### DIFF
--- a/tele_config.gemspec
+++ b/tele_config.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "aws-sdk", "~> 2.0"
+  spec.add_dependency "aws-sdk-s3", "~> 1.9"
 end


### PR DESCRIPTION
Bumps the requires aws-sdk to version 3 which claims to be [backwards compatible](https://github.com/aws/aws-sdk-ruby#upgrading-guide). But instead of getting all of aws-sdk, I solely picked the s3 module of the gem.